### PR TITLE
Order attributes by name if automatically returned for dimension

### DIFF
--- a/babbage/query/fields.py
+++ b/babbage/query/fields.py
@@ -19,7 +19,7 @@ class Fields(Parser):
         """ Define a set of fields to return for a non-aggregated query. """
         info = []
         for field in self.parse(fields):
-            for concept in self.cube.model.match(field):
+            for concept in sorted(self.cube.model.match(field), key=lambda c: c.name):
                 info.append(concept.ref)
                 table, column = concept.bind(self.cube)
                 q = self.ensure_table(q, table)


### PR DESCRIPTION
Changes from the order being defined by their order returned from the python dict
as parsed from the model, to being ordered according to their name. This means
if the set and their order is not specified, you can still predict their order
as returned and queried in the DB to help optimise the DB
