### PR TITLE
Optimise DB query - avoid unnecessary join

### DIFF
--- a/babbage/cube.py
+++ b/babbage/cube.py
@@ -4,6 +4,7 @@ from sqlalchemy.sql.expression import select
 
 from babbage.model import Model
 from babbage.model.dimension import Dimension
+from babbage.model.star_key_attribute import StarKeyAttr
 from babbage.query import count_results, generate_results, first_result
 from babbage.query import Cuts, Drilldowns, Fields, Ordering, Aggregates
 from babbage.query import Pagination
@@ -161,7 +162,7 @@ class Cube(object):
                     dimension = concept
                 else:
                     dimension = concept.dimension
-                dimension_table, key_column = dimension.key_attribute.bind(self)
+                dimension_table, key_column = StarKeyAttr(dimension.key_attribute).bind_star_column(self)
                 if binding.table != dimension_table:
                     raise BindingException('Attributes must be of same table as '
                                            'as their dimension key')

--- a/babbage/model/attribute.py
+++ b/babbage/model/attribute.py
@@ -18,6 +18,18 @@ class Attribute(Concept):
     def datatype(self):
         return self.spec.get('type')
 
+    @property
+    def column_name(self):
+        #        import pdb; pdb.set_trace()
+        if self.dimension.join_column_name and self == self.dimension.key_attribute:
+            return self.dimension.join_column_name
+        else:
+            return self._column_name
+
+    @column_name.setter
+    def column_name(self, val):
+        self._column_name = val
+
     def __repr__(self):
         return "<Attribute(%s)>" % self.ref
 

--- a/babbage/model/star_key_attribute.py
+++ b/babbage/model/star_key_attribute.py
@@ -1,0 +1,19 @@
+from babbage.model.attribute import Attribute
+
+
+class StarKeyAttr(Attribute):
+    def __init__(self, attr):
+        self.attr = attr
+
+    def bind_star_column(self, cube):
+        """
+        Normally when binding a key attribute of a dimension with a dedicated
+        dimension table you want the join_column in the fact table
+        to be used as it might avoid unnecessarily joining to the dimension
+        table. When you know you really want to bind the dimension table,
+        this bind function can be used instead.
+        """
+        table, column = self.attr._physical_column(cube, self.attr._column_name)
+        column = column.label(self.attr.matched_ref)
+        column.quote = True
+        return table, column


### PR DESCRIPTION
I'm not totally sure we should merge this - it's pretty ugly and only takes takes about 9% off the profile page load time. It decreases most queries but seems to increase the load time when the set cut is more than 5 items

```
(jdb)-(05:35 PM Tue May 24)-(~/proj/code4sa/municipal_finance/django-app):
 (profiling) $ grep seconds API*profile.log
API-1390198843868507887-profile.log:         87525 function calls (85744 primitive calls) in 0.661 seconds
API--2910918850599722556-profile.log:         76325 function calls (74829 primitive calls) in 0.236 seconds
API-3609233594666003097-profile.log:         72712 function calls (71384 primitive calls) in 0.412 seconds
API-3958897401025097880-profile.log:         32064 function calls (31675 primitive calls) in 0.102 seconds
API--3990181331287464775-profile.log:         76284 function calls (74788 primitive calls) in 0.240 seconds
API-4312788136040430574-profile.log:         92119 function calls (90213 primitive calls) in 0.416 seconds
API--5184984308384390774-profile.log:         76282 function calls (74788 primitive calls) in 0.241 seconds
API--5916040573992871920-profile.log:         77653 function calls (76159 primitive calls) in 0.428 seconds
API-6676244383913703843-profile.log:         20927 function calls (20602 primitive calls) in 0.061 seconds
API--6868430843821324967-profile.log:         76330 function calls (74834 primitive calls) in 0.244 seconds
API-7503055220119028621-profile.log:         75842 function calls (74514 primitive calls) in 0.364 seconds
API-8393444307019475981-profile.log:         25547 function calls (25224 primitive calls) in 0.063 seconds
API--8971956282474730463-profile.log:         83366 function calls (81705 primitive calls) in 1.180 seconds

(jdb)-(05:36 PM Tue May 24)-(~/proj/code4sa/municipal_finance/django-app):
 (profiling) $ grep seconds API*profile.log
API-1390198843868507887-profile.log:         67918 function calls (66474 primitive calls) in 1.027 seconds
API--2910918850599722556-profile.log:         56873 function calls (55714 primitive calls) in 0.185 seconds
API-3609233594666003097-profile.log:         53045 function calls (52054 primitive calls) in 0.351 seconds
API-3958897401025097880-profile.log:         16536 function calls (16286 primitive calls) in 0.054 seconds
API--3990181331287464775-profile.log:         56860 function calls (55701 primitive calls) in 0.189 seconds
API-4312788136040430574-profile.log:         71431 function calls (69870 primitive calls) in 0.350 seconds
API--5184984308384390774-profile.log:         56857 function calls (55700 primitive calls) in 0.181 seconds
API--5916040573992871920-profile.log:         57984 function calls (56827 primitive calls) in 0.376 seconds
API-6676244383913703843-profile.log:         21008 function calls (20683 primitive calls) in 0.059 seconds
API--6868430843821324967-profile.log:         56879 function calls (55720 primitive calls) in 0.186 seconds
API-7503055220119028621-profile.log:         55436 function calls (54445 primitive calls) in 0.293 seconds
API-8393444307019475981-profile.log:         26032 function calls (25701 primitive calls) in 0.067 seconds
API--8971956282474730463-profile.log:         63733 function calls (62409 primitive calls) in 0.579 seconds
```
